### PR TITLE
LS-244 Catch OpenCL errors and exit at the next scheduler invocation

### DIFF
--- a/src/modules/lecturesight-heartbeat/src/main/java/cv/lecturesight/heartbeat/ConsoleCommands.java
+++ b/src/modules/lecturesight-heartbeat/src/main/java/cv/lecturesight/heartbeat/ConsoleCommands.java
@@ -35,7 +35,7 @@ import org.pmw.tinylog.Logger;
 @Service()
 @Properties({
   @Property(name = "osgi.command.scope", value = "ls"),
-  @Property(name = "osgi.command.function", value = {"run", "stop", "pause", "restart", "step"})
+  @Property(name = "osgi.command.function", value = {"run", "stop", "pause", "restart", "step", "health"})
 })
 public class ConsoleCommands implements DummyInterface {
 
@@ -44,6 +44,12 @@ public class ConsoleCommands implements DummyInterface {
 
   protected void activate(ComponentContext context) {
     Logger.info("Commands activated");
+  }
+
+  public void health(String[] param) {
+    // CHECKSTYLE:OFF
+    System.out.println(main.isAlive() ? "alive" : "dead");
+    // CHECKSTYLE:ON
   }
 
   public void run(String[] param) {

--- a/src/modules/lecturesight-heartbeat/src/main/java/cv/lecturesight/heartbeat/HeartBeatImpl.java
+++ b/src/modules/lecturesight-heartbeat/src/main/java/cv/lecturesight/heartbeat/HeartBeatImpl.java
@@ -189,4 +189,9 @@ public class HeartBeatImpl implements HeartBeat {
   public boolean isRunning() {
     return !(iterationsToRun == 0);
   }
+
+  @Override
+  public boolean isAlive() {
+    return ocl.isAlive();
+  }
 }

--- a/src/modules/lecturesight-heartbeat/src/main/java/cv/lecturesight/heartbeat/api/HeartBeat.java
+++ b/src/modules/lecturesight-heartbeat/src/main/java/cv/lecturesight/heartbeat/api/HeartBeat.java
@@ -21,6 +21,7 @@ public interface HeartBeat {
 
   boolean isReady();
   boolean isRunning();
+  boolean isAlive();
   void init();
   void deinit();
   void step(int i);

--- a/src/modules/lecturesight-opencl-api/src/main/java/cv/lecturesight/opencl/OpenCLService.java
+++ b/src/modules/lecturesight-opencl-api/src/main/java/cv/lecturesight/opencl/OpenCLService.java
@@ -122,4 +122,9 @@ public interface OpenCLService {
   void unregisterTriggerable(OCLSignal trigger, Triggerable handler);
 
   OCLSignalBarrier createSignalBarrier(OCLSignal[] triggers);
+
+ /**
+  * True if the OpenCL service is running
+  */
+  boolean isAlive();
 }

--- a/src/modules/lecturesight-opencl-impl/src/main/java/cv/lecturesight/opencl/impl/OCLExecutor.java
+++ b/src/modules/lecturesight-opencl-impl/src/main/java/cv/lecturesight/opencl/impl/OCLExecutor.java
@@ -62,6 +62,9 @@ public class OCLExecutor extends Thread {
         if (launch(run)) {
           CLEvent marker = oclQueue.enqueueMarker();
           callbackExecutor.execute(new CallbackExecution(marker, run));
+        } else {
+          callbackExecutor.shutdownNow();
+          shutdown();
         }
       }
     } catch (InterruptedException e) {
@@ -123,6 +126,7 @@ public class OCLExecutor extends Thread {
           warn += ": " + msg;
         }
         Logger.error(e, warn);
+        shutdown();
       }
       try {
         if (landing) {
@@ -135,6 +139,7 @@ public class OCLExecutor extends Thread {
           warn += ": " + msg;
         }
         Logger.error(e, warn);
+        shutdown();
       }
     }
   }

--- a/src/modules/lecturesight-opencl-impl/src/main/java/cv/lecturesight/opencl/impl/OpenCLServiceImpl.java
+++ b/src/modules/lecturesight-opencl-impl/src/main/java/cv/lecturesight/opencl/impl/OpenCLServiceImpl.java
@@ -136,4 +136,8 @@ public class OpenCLServiceImpl implements OpenCLService {
     return out;
   }
 
+  @Override
+  public boolean isAlive() {
+    return (executor != null) && executor.isAlive();
+  }
 }

--- a/src/modules/lecturesight-scheduler/pom.xml
+++ b/src/modules/lecturesight-scheduler/pom.xml
@@ -34,6 +34,10 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Production experience with some NVIDIA GPUs shows some occasional errors
which effectively disable further processing (so tracking stops).
These are not known to affect Intel GPUs.

As the underlying cause of these is not known, we should catch these errors
and provide a status indication that OpenCL processing is no longer available.
LectureSight should then exit, so it can be restarted automatically from the
wrapper script or other service monitoring system.