### PR TITLE
LS-242 Start tracking if LS starts up during scheduled event

### DIFF
--- a/src/modules/lecturesight-scheduler/src/main/java/cv/lecturesight/scheduler/DutyScheduler.java
+++ b/src/modules/lecturesight-scheduler/src/main/java/cv/lecturesight/scheduler/DutyScheduler.java
@@ -20,6 +20,7 @@ import org.pmw.tinylog.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -145,9 +146,16 @@ public class DutyScheduler implements ArtifactInstaller, DummyInterface {
 
             // Is this event in progress?
             if (now.after(startDate) && now.before(stopDate)) {
-              Logger.info("Immediate start for event in progress: Start: {} End: {}  UID: {}", startDate, stopDate, vevent.getUID());
-              fireEvent(startTracker);
-              fireEvent(startOperator);
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(stopDate);
+                cal.add(Calendar.SECOND, -10);
+              if (now.before(cal.getTime())) {
+                Logger.info("Immediate start for event in progress: Start: {} End: {}  UID: {}", startDate, stopDate, vevent.getUID());
+                fireEvent(startTracker);
+                fireEvent(startOperator);
+              } else {
+                Logger.info("Ingoring event in progress which finishes within 10s: Start: {} End: {}  UID: {}", startDate, stopDate, vevent.getUID());
+              }
             } else {
               Logger.info("Created recording event: Start: {} End: {}  UID: {}", startDate, stopDate, vevent.getUID());
               newEvents.add(startTracker);

--- a/src/modules/lecturesight-scheduler/src/main/java/cv/lecturesight/scheduler/DutyScheduler.java
+++ b/src/modules/lecturesight-scheduler/src/main/java/cv/lecturesight/scheduler/DutyScheduler.java
@@ -337,19 +337,23 @@ public class DutyScheduler implements ArtifactInstaller, DummyInterface {
         long now = System.currentTimeMillis();   // get current time
         Event current = events.getNextAfter(0);   // get earliest event
 
-        // Step when inactive so that overview images are snapshotted (if configured). This means that
-        // overview images will continue to be processed and displayed at 1fps (execution interval),
-        // without any analysis or camera movement taking place.
-        if (!heart.isRunning()) {
-          heart.step(1);
-        }
+        boolean eventActivity = false;
 
-        // Fire pending events
+        // Fire pending events if there are any
         while ((current != null)  && (current.getTime() <= now)) {
+          eventActivity = true;
           fireEvent(current);
           events.remove(current);
           now = System.currentTimeMillis();
           current = events.getNextAfter(0);
+        }
+
+        // Step when inactive so that overview images are snapshotted (if configured). This means that
+        // overview images will continue to be processed and displayed at 1fps (execution interval),
+        // without any analysis or camera movement taking place.
+        if (!eventActivity && !heart.isRunning()) {
+          // TODO This appears to cause issues with NVIDIA cards
+          // heart.step(1);
         }
       }
     }


### PR DESCRIPTION
This updates the scheduler code so it will start tracking if LectureSight starts up during a scheduled event.

It also disables the step() code when inactive, as this appears to cause issues with NVIDIA cards, for presently unknown reasons.
