### PR TITLE
LS-247 retry v4l device

### DIFF
--- a/src/modules/lecturesight-framesource-v4l/src/main/java/cv/lecturesight/framesource/v4l/V4LFrameGrabberFactory.java
+++ b/src/modules/lecturesight-framesource-v4l/src/main/java/cv/lecturesight/framesource/v4l/V4LFrameGrabberFactory.java
@@ -283,6 +283,7 @@ public class V4LFrameGrabberFactory implements FrameGrabberFactory {
       }
       return device;
     } catch (V4L4JException ex) {
+      Logger.error(ex, "Unable to open capture device {}", name);
       throw new FrameSourceException("Could not open capture device " + name + ": " + ex.getMessage());
     }
   }


### PR DESCRIPTION
Infrequently, opening the v4l2 device (typically a webcam) fails for no apparent reason.

The second attempt works, so retry the operation a number of times if it fails the first time.
